### PR TITLE
feat: add Helsinki timezone

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -3,6 +3,7 @@
 /  /Asia/Hong_Kong        200 Country=hk
 /  /Europe/Bucharest      200 Country=ro
 /  /Europe/Moscow         200 Country=ru
+/  /Europe/Helsinki       200 Country=fi
 /  /Europe/Istanbul       200 Country=tr
 /  /Europe/Paris          200 Country=fr,es,it,se,dk,nl,pl,ch
 /  /Europe/Berlin         200 Country=de

--- a/src/_data/timezones.json
+++ b/src/_data/timezones.json
@@ -5,6 +5,7 @@
   { "location": "Asia/Hong_Kong", "locale": "zh-hk"},
   { "location": "Europe/Bucharest", "locale": "ro"},
   { "location": "Europe/Moscow", "locale": "ru"},
+  { "location": "Europe/Helsinki", "locale": "fi-FI"},
   { "location": "Europe/Istanbul", "locale": "tr"},
   { "location": "Europe/Amsterdam", "locale": "nl-NL"},
   { "location": "Europe/Paris", "locale": "fr-FR"},


### PR DESCRIPTION
- Add Helsinki timezone
  - Adjust `timezones.json` to add Helsinki
  - Adjust `_redirects` to add Helsinki

Potential issues with the filters:

- `coloncapture` filter does not work with the `fi-FI` locale,
  because it uses dot `.` instead of colon `:` as a divider.