### PR TITLE
Adds Argentina timezone and redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -9,6 +9,7 @@
 /  /Europe/London         200 Country=gb,pt
 /  /America/Chicago       200 Country=us
 /  /America/Toronto       200 Country=ca
+/  /America/Buenos_Aires  200 Country=ar
 /  /Africa/Lagos          200 Country=ng
 /  /Asia/Kolkata          200 Country=in
 /  /Asia/Jerusalem        200 Country=il

--- a/src/_data/timezones.json
+++ b/src/_data/timezones.json
@@ -16,6 +16,7 @@
   { "location": "America/Detroit"},
   { "location": "America/Denver"},
   { "location": "America/Los_Angeles"},
+  { "location": "America/Buenos_Aires", "locale": "es-AR"},
   { "location": "Pacific/Honolulu"},
   { "location": "Africa/Lagos"},
   { "location": "Asia/Kolkata", "locale": "en-IN"},


### PR DESCRIPTION
Adds Argentina to time zones.

It's not alphabetically ordered, but in the "America/" section of the list.